### PR TITLE
Derive release version from git tags; create GitHub release on deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,58 +4,16 @@ on:
     branches:
       - main
 jobs:
-  record-release:
+  deploy-production-us:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
         with:
-          java-version: "25"
-          distribution: "corretto"
-          cache: "maven"
-      - name: Retrieving version
-        run: |
-          VERSION_FORMAT='${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}'
-          mvn -q build-helper:parse-version versions:set -DnewVersion="${VERSION_FORMAT}" versions:commit
-          echo "VERSION=$(grep \<version\> pom.xml | xargs | awk -F '[<>]' '{ print $3}')" >> $GITHUB_ENV
-
-      - name: Releasing
-        run: |
-          echo "###################  using version: v$VERSION ###################"
-
-          git config --global user.email "ci@uvasoftware.com"
-          git config --global user.name "Github Actions"
-          git tag -a v"${VERSION}" -m "Release by Github Actions v${VERSION}"
-          git push origin v"${VERSION}"
-
-      - name: Bumping version
-        run: |
-          # shellcheck disable=SC2016
-          VERSION_FORMAT='${parsedVersion.majorVersion}.${parsedVersion.nextMinorVersion}.${parsedVersion.incrementalVersion}-SNAPSHOT'
-          mvn -q build-helper:parse-version versions:set -DnewVersion="${VERSION_FORMAT}" versions:commit
-
-          VERSION=$(grep \<version\> pom.xml | xargs | awk -F '[<>]' '{ print $3}')
-
-          echo "next version is: $VERSION"
-
-          git status
-          git commit -a -m "bump to ${VERSION} [ci skip]"
-          git push origin main
-
-
-  deploy-production-us:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    runs-on: ubuntu-latest
-    needs: [ record-release ]
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
+          fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           java-version: "25"
@@ -72,11 +30,24 @@ jobs:
           role-session-name: gha-scanii-lambda-release
           aws-region: us-east-1
 
-      - name: Strip snapshot marker
+      - name: Compute next version
+        id: version
         run: |
-          # shellcheck disable=SC2016
-          VERSION_FORMAT='${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}'
-          mvn -q build-helper:parse-version versions:set -DnewVersion="${VERSION_FORMAT}" versions:commit
+          LATEST_TAG=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1)
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No prior v* tag found; cannot derive next version." >&2
+            exit 1
+          fi
+          PREV=${LATEST_TAG#v}
+          MAJOR=$(echo "$PREV" | cut -d. -f1)
+          MINOR=$(echo "$PREV" | cut -d. -f2)
+          NEXT="${MAJOR}.$((MINOR + 1)).0"
+          echo "Previous tag: $LATEST_TAG -> Next: v$NEXT"
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "tag=v$NEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Set pom version
+        run: mvn -q versions:set -DnewVersion="${{ steps.version.outputs.version }}" -DgenerateBackupPoms=false
 
       - name: Build
         run: mvn -q -DskipTests clean package
@@ -88,3 +59,13 @@ jobs:
             --s3-prefix sam/guarana \
             --template-file template.yml \
             --output-template-file guarana.yaml
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --target "${{ github.sha }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes "Lambda deployed from ${{ github.sha }} by run ${{ github.run_id }}." \
+            guarana.yaml target/guarana.jar

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <aws.sdk.version>2.46.0</aws.sdk.version>
   </properties>
-
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
## Summary
- The previous workflow's post-release "bump to X.Y.Z-SNAPSHOT" push-to-main step started failing under the new "changes must be made through a PR" repository rule. With the auto-bump gone, deriving the release version from `pom.xml` no longer made sense — every deploy would reuse the same fossilized version.
- The deploy job now computes the next release version from git: take the most recent `v*` tag, bump the minor, reset patch to `0` (so `v1.7.7` → `v1.8.0`). The pom version is set to that value locally so the built jar manifest matches the release.
- After a successful `sam package`, the workflow creates a GitHub release at the computed tag, attaching `guarana.yaml` and `target/guarana.jar` as release assets.
- Removed the `record-release` job; deploy runs on every push to main, no more `[ci skip]` round-tripping.

## Test plan
- [ ] Merge → confirm the workflow run computes the next tag as `v1.8.0` (current latest tag is `v1.7.7`)
- [ ] Confirm OIDC role assumption still succeeds (unchanged from prior run)
- [ ] Confirm `sam package` uploads to `s3://scanii-assets/sam/guarana/`
- [ ] Confirm GitHub release `v1.8.0` is created, targeting the merge commit, with `guarana.yaml` and `guarana.jar` attached
- [ ] Re-run the same workflow run from the UI → second attempt should fail at `gh release create` (tag already exists), which is the intended self-correction; the next merge will compute `v1.9.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)